### PR TITLE
Results now inline with qiime 1.9.1 split_libraries_fastq.py

### DIFF
--- a/q2_quality_filter/_filter.py
+++ b/q2_quality_filter/_filter.py
@@ -111,7 +111,6 @@ def q_score(demux: SingleLanePerSampleSingleEndFastqDirFmt,
             if bad_windows.size > 0:
                 log_records_truncated_counts[sample_id] += 1
 
-                #full_length = qual_below_threshold.size
                 full_length = len(sequence_record[1])
                 sequence_record = _truncate(sequence_record,
                                             run_starts[bad_windows[0]][0])

--- a/q2_quality_filter/_filter.py
+++ b/q2_quality_filter/_filter.py
@@ -105,19 +105,20 @@ def q_score(demux: SingleLanePerSampleSingleEndFastqDirFmt,
             # determine the length of the runs below quality threshold
             qual_below_threshold = sequence_record[4] <= min_quality
             run_starts, run_lengths = _runs_of_ones(qual_below_threshold)
-            bad_windows = np.argwhere(run_lengths >= quality_window)
+            bad_windows = np.argwhere(run_lengths > quality_window)
 
             # if there is a run of sufficient size, truncate it
             if bad_windows.size > 0:
                 log_records_truncated_counts[sample_id] += 1
 
-                full_length = qual_below_threshold.size
+                #full_length = qual_below_threshold.size
+                full_length = len(sequence_record[1])
                 sequence_record = _truncate(sequence_record,
                                             run_starts[bad_windows[0]][0])
                 trunc_length = len(sequence_record[1])
 
                 # do not keep the read if it is too short following truncation
-                if (trunc_length / full_length) < min_length_fraction:
+                if round(trunc_length / full_length, 3) <= min_length_fraction:
                     log_records_tooshort_counts[sample_id] += 1
                     continue
 

--- a/q2_quality_filter/test/test_filter.py
+++ b/q2_quality_filter/test/test_filter.py
@@ -95,7 +95,7 @@ class FilterTests(TestPluginBase):
         self.assertEqual(obs, exp_drop_ambig)
         pdt.assert_frame_equal(stats, exp_drop_ambig_stats.loc[stats.index])
 
-        obs_trunc, stats = q_score(view, quality_window=2, min_quality=32,
+        obs_trunc, stats = q_score(view, quality_window=1, min_quality=32,
                                    min_length_fraction=0.25)
         exp_trunc = ["@foo_1",
                      "ATGCATGC",


### PR DESCRIPTION
This evaluation compared the results of using the MVP tutorial data run through QIIME 1.9.1 and this filter. The number of reads too short following truncation, and the number of reads dropped due to ambiguous bases now align across samples and between q1 and q2.

The script to perform the test is below. The 

```bash
set -x
set -e

curl -sL "https://docs.google.com/spreadsheets/d/1_3ZbqCtAYx-9BJYHoWlICkVJ4W_QGMfJRPLedt_0hws/export?gid=0&format=tsv" > sample-metadata.tsv
curl -O https://docs.qiime2.org/2.0.6/data/tutorials/moving-pictures/demux.qza
unzip demux.qza

mkdir slout
pushd 589ad4da-6444-487d-8267-65dff627db1f/data/
source activate qiime191
for i in *.fastq.gz
do
    sid=$(echo "${i}" | awk -F'_' '{ print $1 }')
    split_libraries_fastq.py -i ${i} -o ${sid}-slout -q 19 --sample_ids ${sid} --barcode_type 'not-barcoded'
    mv ${sid}-slout ../../slout/
done
popd

source activate qiime2
# the offset in the tutorial data is incorrect
sed -i 's/33/64/' 589ad4da-6444-487d-8267-65dff627db1f/data/metadata.yml
zip -r 589ad4da-6444-487d-8267-65dff627db1f 589ad4da-6444-487d-8267-65dff627db1f
qiime quality-filter q-score --i-demux 589ad4da-6444-487d-8267-65dff627db1f.zip --o-filtered-sequences qfout --o-filter-stats qfoutstats
qiime quality-filter visualize-stats --i-filter-stats qfoutstats.qza --o-visualization qfstats
```

Results were then spot checked examining the `split_libraries_log.txt` files and `qfstats` in `view.qiime2.org`.